### PR TITLE
Title encoding is not specified as utf-8

### DIFF
--- a/custom_components/ntfy/notify.py
+++ b/custom_components/ntfy/notify.py
@@ -110,7 +110,7 @@ class NtfyNotificationService(BaseNotificationService):
         req_data=message.encode('utf-8')
 
         if title is not None:
-            req_headers["Title"] = title
+            req_headers["Title"] = title.encode('utf-8')
 
         if "tags" in data:
             # TODO: validate tag format


### PR DESCRIPTION
Errors occur when sending non-English messages because the encoding of the title is not set to utf-8.