### PR TITLE
Fix http call to home assistant

### DIFF
--- a/custom_components/ntfy/notify.py
+++ b/custom_components/ntfy/notify.py
@@ -306,22 +306,25 @@ class NtfyNotificationService(BaseNotificationService):
 
 
     def _build_actions_header_http(self, action):
+        _LOGGER.debug("action: %s", action)
         tmp_header:str = ''
         tmp_header += f"http, {action['label']}, {action['url']}"
 
         if action.get('method', None):
             tmp_header +=f", method={action.get('method')}"
-
+               
         if action.get('headers', []):
-            for key, value in action.get('extras').items():
+            for key, value in action.get('headers').items():
                 tmp_header += f", headers.{key}={value}"
-
+        
         if action.get('clear', False):
             tmp_header += ', clear=true'
 
         if action.get('body', None):
-            body = action.get('body','').replace('"', '\\"').replace("'", "\\'").replace('=', '\\=')
+            body = action.get('body','').replace('"', '\"').replace("'", "\'").replace('=', '\=')
             tmp_header += f", body={body}"
+
+        _LOGGER.debug("Tmp header: %s", tmp_header)
 
         return tmp_header
 


### PR DESCRIPTION
I have a solution to allow to use the http 'action' from ntfy, it required a typo-fix and a minor change to the formatting.
The below works with this changed code:

```
action: notify.ntfy_ha
data:
  title: Homeassistant Notification
  message: Movement in backyard detected
  data:
    topic: test
    actions:
      - action: http
        label: Light living room on
        method: POST
        url: https://https-address-of-ha/api/services/switch/turn_on
        headers:
          Authorization: >-
            Bearer 123456789......
          Content-type: application/json
        body: "{\"entity_id\": \"switch.living-room\"}"